### PR TITLE
Remove device enabling-disabling and elevated rights

### DIFF
--- a/Source/HidLibrary/HidDevice.cs
+++ b/Source/HidLibrary/HidDevice.cs
@@ -445,11 +445,6 @@ namespace HidLibrary
             return success;
         }
 
-        public bool SetState(bool enabled)
-        {
-            return HidDevices.SetDeviceState(_devicePath, enabled);
-        }
-
         protected static void EndRead(IAsyncResult ar)
         {
             var hidAsyncState = (HidAsyncState)ar.AsyncState;

--- a/Source/HidLibrary/NativeMethods.cs
+++ b/Source/HidLibrary/NativeMethods.cs
@@ -78,12 +78,7 @@ namespace HidLibrary
 	    internal const short DIGCF_DEVICEINTERFACE = 0x10;
 	    internal const int DIGCF_ALLCLASSES = 0x4;
 
-        internal const int DIF_PROPERTYCHANGE = 0x12;
-        internal const int DICS_ENABLE = 1;
-        internal const int DICS_DISABLE = 2; // disable device
-        internal const int DICS_FLAG_GLOBAL = 1; // not profile-specific
-
-        internal const int MAX_DEV_LEN = 1000;
+	    internal const int MAX_DEV_LEN = 1000;
 	    internal const int SPDRP_ADDRESS = 0x1c;
 	    internal const int SPDRP_BUSNUMBER = 0x15;
 	    internal const int SPDRP_BUSTYPEGUID = 0x13;
@@ -190,22 +185,6 @@ namespace HidLibrary
             public ulong pid;
         }
 
-        [StructLayout(LayoutKind.Sequential)]
-        internal struct SP_CLASSINSTALL_HEADER
-        {
-            public int cbSize;
-            public int InstallFunction;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        internal struct SP_PROPCHANGE_PARAMS
-        {
-            public SP_CLASSINSTALL_HEADER ClassInstallHeader;
-            public int StateChange;
-            public int Scope;
-            public int HwProfile;
-        }
-
         internal static DEVPROPKEY DEVPKEY_Device_BusReportedDeviceDesc = 
             new DEVPROPKEY { fmtid = new Guid(0x540b947e, 0x8b40, 0x45bc, 0xa8, 0xa2, 0x6a, 0x0b, 0x89, 0x4c, 0xbd, 0xa2), pid = 4 };
 
@@ -239,19 +218,7 @@ namespace HidLibrary
 	    [DllImport("setupapi.dll", CharSet = CharSet.Auto)]
 	    static internal extern bool SetupDiGetDeviceInterfaceDetail(IntPtr deviceInfoSet, ref SP_DEVICE_INTERFACE_DATA deviceInterfaceData, ref SP_DEVICE_INTERFACE_DETAIL_DATA deviceInterfaceDetailData, int deviceInterfaceDetailDataSize, ref int requiredSize, IntPtr deviceInfoData);
 
-        [DllImport("setupapi.dll", CharSet = CharSet.Auto, SetLastError = true)]
-        public static extern bool SetupDiSetClassInstallParams(
-            IntPtr deviceInfoSet,
-            [In] ref SP_DEVINFO_DATA deviceInfoData,
-            [In] ref SP_PROPCHANGE_PARAMS classInstallParams,
-            UInt32 ClassInstallParamsSize);
-
-        [DllImport("setupapi.dll", CharSet = CharSet.Auto, SetLastError = true)]
-        public static extern bool SetupDiChangeState(
-            IntPtr deviceInfoSet,
-            [In] ref SP_DEVINFO_DATA deviceInfoData);
-
-        [DllImport("user32.dll")]
+	    [DllImport("user32.dll")]
 	    static internal extern bool UnregisterDeviceNotification(IntPtr handle);
 
 	    internal const short HIDP_INPUT = 0;

--- a/Source/mi-360/MiGamepad.cs
+++ b/Source/mi-360/MiGamepad.cs
@@ -105,22 +105,9 @@ namespace mi360
             _InputThread.Join();
         }
 
-        public void DisableReEnableDevice()
-        {
-            _Logger.Information("Disabling gamepad {Device}", _Device);
-            if (!_Device.SetState(false))
-                _Logger.Error("Cannot disable device {Device}", _Device);
-
-            _Logger.Information("Enabling gamepad {Device}", _Device);
-            if (!_Device.SetState(true))
-                _Logger.Error("Cannot enable device {Device}", _Device);
-        }
-
         private void DeviceWorker()
         {
             _Logger.Information("Starting worker thread for {Device}", _Device);
-
-            DisableReEnableDevice();
 
             // Open HID device to read input from the gamepad
             _Logger.Information("Opening HID device {Device}", _Device);
@@ -267,8 +254,6 @@ namespace mi360
             // Close the HID device
             _Logger.Information("Closing HID device {Device}", _Device);
             _Device.CloseDevice();
-
-            DisableReEnableDevice();
 
             _Logger.Information("Exiting worker thread for {0}", _Device.ToString());
             Ended?.Invoke(this, EventArgs.Empty);

--- a/Source/mi-360/app.manifest
+++ b/Source/mi-360/app.manifest
@@ -16,7 +16,7 @@
             Rimuovere questo elemento se l'applicazione richiede questa virtualizzazione per
             compatibilità con le versioni precedenti.
         -->
-        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+        <!--<requestedExecutionLevel level="requireAdministrator" uiAccess="false" />-->
       </requestedPrivileges>
     </security>
   </trustInfo>


### PR DESCRIPTION
Apparently disabling and re-enabling devices does not help in removing non-present ones (Windows gets no notifications when Xiaomi Gamepad turns off and believe it is still there). Disconnection event will trigger when trying to access the HID device for the first time, and it seems to be enough